### PR TITLE
Replay analysis and tie ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ inne++ will send you a text file containing all level and episode high scores fo
 - *\<challenge\> video for \<level\> by \<user\>*
 
 ### Analyze replays
-- *analysis for \<level-name\> \<rank a\> \<rank b\> ...*
+- *analysis for \<level-id\> \<rank a\> \<rank b\> ...*
 
-inne++ will download and analyze the inputs of a group of runs with ranks *\<rank a\>*, *\<rank b\>*... from level *\<level-name\>*. You can introduce as many ranks as you want, as long as they are separated by spaces. You need to introduce the level name in it's short form (e.g. S-A-15-03) rather than its long name (e.g. "neo tokyo") to avoid confusing inne with the also introduced ranks.
+inne++ will download and analyze the inputs of a group of runs with ranks *\<rank a\>*, *\<rank b\>*... from level *\<level-id\>*. You can introduce as many ranks as you want, as long as they are separated by spaces. You need to introduce the level id (e.g. S-A-15-03) rather than its name (e.g. "neo tokyo") to avoid confusing inne with the also introduced ranks.
 
 ### Initialize inne++
 - *hello*

--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ If a rank isn't specified, inne++ defaults to top 20.
 
 inne++ will send you a text file containing all level and episode high scores for the specified user listed by rank. You can filter only the 0ths, or only the top or bottom ones. You can use both options at the same time to obtain only the score between 2 ranks of your choice. As usual, you can filter by tabs.
 
+### Analyze replays
+- *analysis for \<level-name\> \<rank a\> \<rank b\> ...*
+
+inne++ will download and analyze the inputs of a group of runs with ranks *\<rank a\>*, *\<rank b\>*... from level *\<level-name\>*. You can introduce as many ranks as you want, as long as they are separated by spaces. You need to introduce the level name in it's short form (e.g. S-A-15-03) rather than its long name (e.g. "neo tokyo") to avoid confusing inne with the also introduced ranks.
+
 ### Initialize inne++
 - *hello*
 - *hi*

--- a/db/config.yml
+++ b/db/config.yml
@@ -8,19 +8,19 @@ inne_eddy:
   #episode_update_frequency: 60
 
 development:
-    adapter: sqlite3
-    database: inne-dev.db
-    level_update_frequency: 60
-    episode_update_frequency: 460
-    #host: localhost
-    #  username: inne
-    #  password: '#69inne#69'
-    #  encoding: utf8mb4
-    #  collation: utf8mb4_unicode_ci
-    token: Mjk2MjE3NTkyODA3NDI0MDAw.C7vBqA.2N95P6C0RMnYkdPobKvao4thJ3g
-    client_id: 296217592807424000
-    #  level_update_frequency: 60
-    #  episode_update_frequency: 460
+  adapter: sqlite3
+  database: inne-dev.db
+  level_update_frequency: 60
+  episode_update_frequency: 460
+  #host: localhost
+  #  username: inne
+  #  password: '#69inne#69'
+  #  encoding: utf8mb4
+  #  collation: utf8mb4_unicode_ci
+  token: Mjk2MjE3NTkyODA3NDI0MDAw.C7vBqA.2N95P6C0RMnYkdPobKvao4thJ3g
+  client_id: 296217592807424000
+  #  level_update_frequency: 60
+  #  episode_update_frequency: 460
 
 production:
   adapter: mysql2

--- a/inne++.rb
+++ b/inne++.rb
@@ -8,7 +8,7 @@ require_relative 'messages.rb'
 
 require 'byebug'
 
-DATABASE_ENV = ENV['DATABASE_ENV'] || 'development'
+DATABASE_ENV = ENV['DATABASE_ENV'] || 'inne_eddy'
 CONFIG = YAML.load_file('db/config.yml')[DATABASE_ENV]
 
 HIGHSCORE_UPDATE_FREQUENCY = 24 * 60 * 60 # daily
@@ -65,6 +65,12 @@ end
 def set_last_steam_id(id)
   GlobalProperty.find_or_create_by(key: "last_steam_id")
     .update(value: id)
+end
+
+def update_last_steam_id
+  current = User.find_by(steam_id: get_last_steam_id).id
+  next_user = User.where.not(steam_id: nil).where('id > ?', current).first || User.where.not(steam_id: nil).first
+  set_last_steam_id(next_user.steam_id) if !next_user.nil?
 end
 
 def download_high_scores
@@ -271,7 +277,7 @@ startup
 trap("INT") { $kill_threads = true }
 
 $threads = [
-  Thread.new { start_level_of_the_day },
+  #Thread.new { start_level_of_the_day },
   Thread.new { download_high_scores },
 ]
 

--- a/inne++.rb
+++ b/inne++.rb
@@ -80,8 +80,8 @@ def download_high_scores
     while true
       log("updating high scores...")
 
-      Level.all.each(&:download_scores)
-      Episode.all.each(&:download_scores)
+      Level.all.each(&:update_scores)
+      Episode.all.each(&:update_scores)
 
       log("updated high scores. updating rankings...")
 
@@ -191,8 +191,8 @@ def send_channel_next(type)
     return false
   end
 
-  last.download_scores
-  current.download_scores
+  last.update_scores
+  current.update_scores
 
   prefix = type == Level ? "Time" : "It's also time"
   duration = type == Level ? "day" : "week"
@@ -277,7 +277,7 @@ startup
 trap("INT") { $kill_threads = true }
 
 $threads = [
-  #Thread.new { start_level_of_the_day },
+  Thread.new { start_level_of_the_day },
   Thread.new { download_high_scores },
 ]
 

--- a/inne++.rb
+++ b/inne++.rb
@@ -8,7 +8,7 @@ require_relative 'messages.rb'
 
 require 'byebug'
 
-DATABASE_ENV = ENV['DATABASE_ENV'] || 'inne_eddy'
+DATABASE_ENV = ENV['DATABASE_ENV'] || 'development'
 CONFIG = YAML.load_file('db/config.yml')[DATABASE_ENV]
 
 HIGHSCORE_UPDATE_FREQUENCY = 24 * 60 * 60 # daily

--- a/messages.rb
+++ b/messages.rb
@@ -571,7 +571,7 @@ def send_analysis(event)
   header = "Replay analysis for #{scores.format_name} #{format_time}.\n#{properties}\n#{explanation}"
 
   result = "#{header}\n```#{key_result}```"
-  if result.size > 2000 then result = result[0..1994] + "...```" end
+  if result.size > 2000 then result = result[0..1993] + "...```" end
   event << "#{result}"
   tmpfile = File.join(Dir.tmpdir, "analysis-#{scores.name}.txt")
   File::open(tmpfile, "w", crlf_newline: true) do |f|

--- a/models.rb
+++ b/models.rb
@@ -89,7 +89,7 @@ module HighScore
     retry
   end
 
-  def update_scores(updated)
+  def save_scores(updated)
     updated = updated.select { |score| !IGNORED_PLAYERS.include?(score['user_name']) }.uniq { |score| score['user_name'] }
 
     ActiveRecord::Base.transaction do
@@ -104,7 +104,7 @@ module HighScore
     end
   end
 
-  def download_scores(rank = nil)
+  def update_scores
     updated = get_scores
 
     if updated.nil?
@@ -113,7 +113,19 @@ module HighScore
       return
     end
 
-    rank.nil? ? update_scores(updated) : updated.select { |score| !IGNORED_PLAYERS.include?(score['user_name']) }.uniq { |score| score['user_name'] }[rank]
+    save_scores(updated)
+  end
+
+  def get_replay_info(rank)
+    updated = get_scores
+
+    if updated.nil?
+      # TODO make this use err()
+      STDERR.puts "[WARNING] [#{Time.now}] failed to retrieve replay info from #{scores_uri(get_last_steam_id)}"
+      return
+    end
+
+    updated.select { |score| !IGNORED_PLAYERS.include?(score['user_name']) }.uniq { |score| score['user_name'] }[rank]
   end
 
   # Replay data format: Unknown (4b), replay ID (4b), level ID (4b), user ID (4b) and demo data compressed with Zlib.


### PR DESCRIPTION
When ordering ties, both the actual order of the list received from the server and the rank field are wrong in some levels, probably being vestiges from before the ties issue was corrected in 2017, hence showing wrongly in inne. We concluded in the Discord that N++ uses the replay id to determine the proper order for tied scores, so I've added a quick method to correct the ties of received scores and now it's working properly.

Secondly, I finished implemented the replay analysis function for inne, which also forces to require the zlib library. Since downloading the replay is a process very similar to downloading a leaderboard, instead of creating a whole new set of methods I've modified the old ones slightly with an optional parameter to adapt them to also downloading replays.